### PR TITLE
Ensure that the generate command creates files that pass mypy checks

### DIFF
--- a/src/pymongo_migrate/generate.py
+++ b/src/pymongo_migrate/generate.py
@@ -7,6 +7,8 @@ MIGRATION_MODULE_TMPL = '''\
 """
 {description}
 """
+import pymongo
+
 name = {name!r}
 dependencies = {dependencies!r}
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -50,6 +50,8 @@ def test_generate(invoker, db, db_uri, tmp_path):
 """
 Migration description here!
 """
+import pymongo
+
 name = '20190203040506'
 dependencies = []
 

--- a/tests/test_mongo_migrate_generate.py
+++ b/tests/test_mongo_migrate_generate.py
@@ -20,6 +20,8 @@ def test_generate(mongo_migrate, tmp_path):
 """
 Migration description here!
 """
+import pymongo
+
 name = '20190225011356'
 dependencies = ['20181123000000_gt_500']
 
@@ -63,6 +65,8 @@ def test_generate_initial_migration(mongo_migrate_with_empty_dir, empty_migratio
 """
 Migration description here!
 """
+import pymongo
+
 name = '20190203040506'
 dependencies = []
 


### PR DESCRIPTION
When you run mypy on the file that is produced with `pymongo-migrate generate` it produces errors:

```
$ mypy migration.py
migration.py:8: error: Name "pymongo" is not defined
migration.py:12: error: Name "pymongo" is not defined
```

This is because the type of `db` is not imported. Adding a `import pymongo` statement in the template fixes these errors.