### PR TITLE
migration file name to have a datetime as prefixed

### DIFF
--- a/src/pymongo_migrate/generate.py
+++ b/src/pymongo_migrate/generate.py
@@ -48,12 +48,15 @@ def generate_migration_module_in_dir(
     migration_dir: Path, name: str = "", *args, **kwargs
 ) -> Path:
     now = datetime.datetime.utcnow()
+    now = f"{now:%Y%m%d%H%M%S}"
     if not name:
-        name = f"{now:%Y%m%d%H%M%S}"
+        name = now
         description = kwargs.get("description")
         if description:
             name = f"{name}_{slugify(description)}"
         name = name[:MAX_NAME_LEN]
+    else:
+        name = f"{now}_{name}" # migrationn file name to have a datetime as prefixed
     file_path = migration_dir / f"{name}.py"
     if file_path.exists():
         raise FileExistsError(f"{file_path} already exists")


### PR DESCRIPTION
example 
pymongo-migrate generate abcd
will create a file named "20230915235959_abcd.py"