### PR TITLE
Fix template types

### DIFF
--- a/src/pymongo_migrate/generate.py
+++ b/src/pymongo_migrate/generate.py
@@ -8,16 +8,17 @@ MIGRATION_MODULE_TMPL = '''\
 {description}
 """
 import pymongo
+import pymongo.database
 
 name = {name!r}
 dependencies = {dependencies!r}
 
 
-def upgrade(db: "pymongo.database.Database"):
+def upgrade(db: pymongo.database.Database):
     pass
 
 
-def downgrade(db: "pymongo.database.Database"):
+def downgrade(db: pymongo.database.Database):
     pass
 '''
 MAX_NAME_LEN = 60


### PR DESCRIPTION
Otherwise we get

```
.../pymongo_migrations/20241203_initial.py:11:26 - error: "database" is not a known attribute of module "pymongo" (reportAttributeAccessIssue)
Error: "database" is not a known attribute of module "pymongo" (reportAttributeAccessIssue)
```